### PR TITLE
specify git work-tree: pull to correct dir

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -6,7 +6,7 @@
 # update the network-profiles
 
 touch .network_profiles_commit
-git --git-dir=network-profiles/.git/ pull
+git --git-dir=network-profiles/.git/ --work-tree=network-profiles/ pull
 latest_commit="$(git --git-dir=network-profiles/.git/ log --pretty=format:'%h' -n 1)"
 if [ "$latest_commit" != "$(cat .network_profiles_commit)" -o -n "$FORCE_REBUILD" ]; then
     echo "$latest_commit" > .network_profiles_commit


### PR DESCRIPTION
In the git command, the `--work-tree` option has to be specified together with the `--git-dir` option so that the new files gets downloaded in the specified directory rather than in the current directory (out from the network-profiles repository directory).