### PR TITLE
copy profile into community, not into profile

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -44,7 +44,7 @@ for community_org in $(ls ./network-profiles); do
 
         # copy all profile specific files
         cp -r "./network-profiles/$community_org/$profile_org/" \
-            "./packages/$community/$profile"
+            "./packages/$community/"
 
         # if special packages are required for the profile parse them here
         packages=""

--- a/update.sh
+++ b/update.sh
@@ -43,7 +43,7 @@ for community_org in $(ls ./network-profiles); do
         profile="$(echo $profile_org | sed -e s/[^A-Za-z0-9\-]/_/g)"
 
         # copy all profile specific files
-        cp -r "./network-profiles/$community_org/$profile_org/" \
+        cp -rp "./network-profiles/$community_org/$profile_org/" \
             "./packages/$community/"
 
         # if special packages are required for the profile parse them here


### PR DESCRIPTION
The current copy command copies the new profile directory into the old profile directory.

After the copy, we will have something wrong:

`community/outdatedProfile/updatedProfile`

rather than

`community/updatedProfile`