### PR TITLE
use plus in dependencies

### DIFF
--- a/templates/Makefile.profile
+++ b/templates/Makefile.profile
@@ -4,7 +4,7 @@ define Package/{{ community }}-{{ profile }}
   TITLE:={{ profile }}
   URL:=https://github.com/libremesh/network-profiles/
   PKGARCH:=all
-  DEPENDS:=lime-system {{ packages }}
+  DEPENDS:=+lime-system {{ packages }}
   PROVIDES:=libremesh-profile
 endef
 

--- a/update.sh
+++ b/update.sh
@@ -51,7 +51,7 @@ for community_org in $(ls ./network-profiles); do
         [ -e "./packages/$community/$profile/PACKAGES" ] && {
             for p in $(cat ./packages/$community/$profile/PACKAGES); do
               # negative packages are discarted
-              packages="$packages $(echo -n "$p" | grep -v "^-")"
+              packages="$packages $(echo -n "+$p" | grep -v "^+-")"
             done
             # replace \n with a whiespace
             # packages="${packages//$'\n'/ }"


### PR DESCRIPTION
Using the plus `+` in front of the dependencies makes easier to select the network profiles in buildroot using menuconfig.
All the network profiles will appear in the submenu once `dnsmasq` gets deselected (due to a condtional dependency of lime-proto-anygw).
This way to use network packages with menuconfig is currently possible just locally but it will be convenient when #2 is solved.